### PR TITLE
Fix backup if LFS is disabled to bypass upstream error

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -43,7 +43,10 @@
     command: >
       gitea dump
       --type {{ _backup_file_suffix }}
-      --file /tmp/{{ _backup_file_prefix }}
+      --custom-path /tmp/
+      --file {{ _backup_file_prefix }}
+      --skip-lfs-data
+      --skip-index
 
 - name: Generate the backup file name.
   set_fact:


### PR DESCRIPTION
  - Bypasses the error here: https://github.com/go-gitea/gitea/pull/23730
  - Explicitly skips LFS data, if you're not TEN7 and use this, be careful!
  - Also skips Index from backup, since this doesn't take long to regenerate.
  - Changes the flags of the backup command to match what appears to be recommended when running gitea dump --help